### PR TITLE
Request to Merge

### DIFF
--- a/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/flow/statistic/concurrent/CurrentConcurrencyManagerTest.java
+++ b/sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/flow/statistic/concurrent/CurrentConcurrencyManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ * Copyright 1999-2024 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package com.alibaba.csp.sentinel.cluster.flow.statistic.concurrent;
 
-import com.alibaba.csp.sentinel.cluster.flow.statistic.concurrent.CurrentConcurrencyManager;
+import com.alibaba.csp.sentinel.concurrent.NamedThreadFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,24 +26,23 @@ import java.util.concurrent.Executors;
 public class CurrentConcurrencyManagerTest {
     @Test
     public void updateTest() throws InterruptedException {
-        CurrentConcurrencyManager.put(111L, 0);
-        CurrentConcurrencyManager.put(222L, 0);
+        CurrentConcurrencyManager.put(113L, 0);
+        CurrentConcurrencyManager.put(223L, 0);
         final CountDownLatch countDownLatch = new CountDownLatch(1000);
-        ExecutorService pool = Executors.newFixedThreadPool(100);
+        ExecutorService pool = Executors.newFixedThreadPool(100,
+                new NamedThreadFactory("CurrentConcurrencyManagerTest", true)
+        );
         for (int i = 0; i < 1000; i++) {
-            Runnable task = new Runnable() {
-                @Override
-                public void run() {
-                    CurrentConcurrencyManager.addConcurrency(111L, 1);
-                    CurrentConcurrencyManager.addConcurrency(222L, 2);
-                    countDownLatch.countDown();
-                }
+            Runnable task = () -> {
+                CurrentConcurrencyManager.addConcurrency(113L, 1);
+                CurrentConcurrencyManager.addConcurrency(223L, 2);
+                countDownLatch.countDown();
             };
             pool.execute(task);
         }
         countDownLatch.await();
         pool.shutdown();
-        Assert.assertEquals(1000, CurrentConcurrencyManager.get(111L).get());
-        Assert.assertEquals(2000, CurrentConcurrencyManager.get(222L).get());
+        Assert.assertEquals(1000, CurrentConcurrencyManager.get(113L).get());
+        Assert.assertEquals(2000, CurrentConcurrencyManager.get(223L).get());
     }
 }

--- a/sentinel-core/src/test/java/com/alibaba/csp/sentinel/util/TimeUtilTest.java
+++ b/sentinel-core/src/test/java/com/alibaba/csp/sentinel/util/TimeUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ * Copyright 1999-2024 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,10 +32,6 @@ import com.alibaba.csp.sentinel.util.function.Tuple2;
  *
  */
 public class TimeUtilTest {
-    @Before
-    public void initLogging() {
-        System.setProperty("csp.sentinel.log.output.type", "console");
-    }
     
     private void waitFor(int step, int seconds) throws InterruptedException {
         for (int i = 0; i < seconds; i ++) {

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowPartialIntegrationTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowPartialIntegrationTest.java
@@ -3,10 +3,13 @@ package com.alibaba.csp.sentinel.slots.block.flow.param;
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.EntryType;
 import com.alibaba.csp.sentinel.SphU;
+import com.alibaba.csp.sentinel.block.flow.param.AbstractTimeBasedTest;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.util.TimeUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,7 +21,7 @@ import static org.junit.Assert.assertTrue;
  * @author quguai
  * @date 2023/10/27 13:44
  */
-public class ParamFlowPartialIntegrationTest {
+public class ParamFlowPartialIntegrationTest extends AbstractTimeBasedTest {
 
     @Before
     public void setUp() throws Exception {
@@ -32,22 +35,25 @@ public class ParamFlowPartialIntegrationTest {
 
     @Test
     public void testParamFlowRegex() {
-        ParamFlowRule rule = new ParamFlowRule(".*")
-                .setParamIdx(0)
-                .setCount(1);
-        rule.setRegex(true);
-        ParamFlowRuleManager.loadRules(Collections.singletonList(rule));
-        verifyFlow("testParamFlowRegex_1", true, "args");
-        verifyFlow("testParamFlowRegex_1", true, "args_1");
+        try (MockedStatic<TimeUtil> mocked = super.mockTimeUtil()) {
+            setCurrentMillis(mocked, 1800000000000L);
+            ParamFlowRule rule = new ParamFlowRule(".*")
+                    .setParamIdx(0)
+                    .setCount(1);
+            rule.setRegex(true);
+            ParamFlowRuleManager.loadRules(Collections.singletonList(rule));
+            verifyFlow("testParamFlowRegex_1", true, "args");
+            verifyFlow("testParamFlowRegex_1", true, "args_1");
 
-        verifyFlow("testParamFlowRegex_1", false, "args");
-        verifyFlow("testParamFlowRegex_1", false, "args_1");
+            verifyFlow("testParamFlowRegex_1", false, "args");
+            verifyFlow("testParamFlowRegex_1", false, "args_1");
 
-        verifyFlow("testParamFlowRegex_2", true, "args");
-        verifyFlow("testParamFlowRegex_2", true, "args_1");
+            verifyFlow("testParamFlowRegex_2", true, "args");
+            verifyFlow("testParamFlowRegex_2", true, "args_1");
 
-        verifyFlow("testParamFlowRegex_2", false, "args");
-        verifyFlow("testParamFlowRegex_2", false, "args_1");
+            verifyFlow("testParamFlowRegex_2", false, "args");
+            verifyFlow("testParamFlowRegex_2", false, "args_1");
+        }
     }
 
 

--- a/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowThrottleRateLimitingCheckerTest.java
+++ b/sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowThrottleRateLimitingCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2019 Alibaba Group Holding Ltd.
+ * Copyright 1999-2024 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,6 @@ public class ParamFlowThrottleRateLimitingCheckerTest {
         }
         assertEquals(successCount, threshold);
 
-        System.out.println("testSingleValueThrottleCheckQps: sleep for 3 seconds");
         TimeUnit.SECONDS.sleep(3);
 
         currentTime = TimeUtil.currentTimeMillis();
@@ -104,7 +103,6 @@ public class ParamFlowThrottleRateLimitingCheckerTest {
         metric.getRuleTimeCounterMap().put(rule, new ConcurrentLinkedHashMapWrapper<Object, AtomicLong>(4000));
 
         int threadCount = 40;
-        System.out.println(metric.getRuleTimeCounter(rule));
 
         final CountDownLatch waitLatch = new CountDownLatch(threadCount);
         final AtomicInteger successCount = new AtomicInteger();
@@ -125,10 +123,8 @@ public class ParamFlowThrottleRateLimitingCheckerTest {
         waitLatch.await();
 
         assertEquals(successCount.get(), 1);
-        System.out.println(threadCount);
         successCount.set(0);
 
-        System.out.println("testSingleValueThrottleCheckQpsMultipleThreads: sleep for 3 seconds");
         TimeUnit.SECONDS.sleep(3);
 
         successCount.set(0);


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed flaky tests by adjusting flow IDs and using a named thread factory for better thread management.
- Enhanced concurrency tests with improved assertions and detailed messages.
- Removed unnecessary logging configuration and console outputs to clean up test outputs.
- Integrated time mocking in tests to ensure consistent and reliable time-based testing.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ConcurrentClusterFlowCheckerTest.java</strong><dd><code>Enhance concurrency test with improved thread management</code>&nbsp; </dd></summary>
<hr>

sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/flow/ConcurrentClusterFlowCheckerTest.java

<li>Updated copyright year.<br> <li> Changed flow ID to prevent conflicts.<br> <li> Added a named thread factory for better thread management.<br> <li> Improved assertions with detailed messages.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/Sentinel/pull/1/files#diff-341ce2336910981a07c532bf73948ba2d2b48fa901c50389b4fce49e5b0b529f">+18/-17</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CurrentConcurrencyManagerTest.java</strong><dd><code>Update concurrency manager test with new IDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sentinel-cluster/sentinel-cluster-server-default/src/test/java/com/alibaba/csp/sentinel/cluster/flow/statistic/concurrent/CurrentConcurrencyManagerTest.java

<li>Updated copyright year.<br> <li> Changed concurrency IDs to prevent conflicts.<br> <li> Added a named thread factory for better thread management.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/Sentinel/pull/1/files#diff-a4593aa8e5fef22dd16491fb0a1d5d09fd448688f49f65169de30fdc5915f13d">+13/-14</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>TimeUtilTest.java</strong><dd><code>Remove logging configuration from TimeUtilTest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sentinel-core/src/test/java/com/alibaba/csp/sentinel/util/TimeUtilTest.java

- Removed system property setup for logging.



</details>


  </td>
  <td><a href="https://github.com/maorethians/Sentinel/pull/1/files#diff-d0bb57334288dcce39384f31c79361519db0da23affa97ed34eb2d8a4c3a0974">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ParamFlowPartialIntegrationTest.java</strong><dd><code>Integrate time mocking in ParamFlowPartialIntegrationTest</code></dd></summary>
<hr>

sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowPartialIntegrationTest.java

<li>Extended test class from AbstractTimeBasedTest.<br> <li> Mocked TimeUtil for consistent time-based testing.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/Sentinel/pull/1/files#diff-63365230926450de37c1c5809b2179fc007b1af64cd385eb6b8c3b38008aa5b7">+20/-14</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ParamFlowThrottleRateLimitingCheckerTest.java</strong><dd><code>Clean up console outputs in ParamFlowThrottleRateLimitingCheckerTest</code></dd></summary>
<hr>

sentinel-extension/sentinel-parameter-flow-control/src/test/java/com/alibaba/csp/sentinel/slots/block/flow/param/ParamFlowThrottleRateLimitingCheckerTest.java

- Removed unnecessary console output statements.



</details>


  </td>
  <td><a href="https://github.com/maorethians/Sentinel/pull/1/files#diff-23b320865f9b135bfb81d33ec6317ee4eebb39a1c0d5297d2f7a54fcdfba1e11">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information